### PR TITLE
Add ability to show names instead of channel codes

### DIFF
--- a/Valve3/pom.xml
+++ b/Valve3/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.usgs.volcanoes</groupId>
     <artifactId>valve</artifactId>
-    <version>3.6.3</version>
+    <version>3.7.0</version>
   </parent>
   <artifactId>valve3</artifactId>
   <packaging>jar</packaging>

--- a/Valve3/src/main/java/gov/usgs/volcanoes/valve3/plotter/GenericFixedPlotter.java
+++ b/Valve3/src/main/java/gov/usgs/volcanoes/valve3/plotter/GenericFixedPlotter.java
@@ -8,7 +8,6 @@ import gov.usgs.volcanoes.core.legacy.util.Pool;
 import gov.usgs.volcanoes.core.math.Butterworth;
 import gov.usgs.volcanoes.core.math.Butterworth.FilterType;
 import gov.usgs.volcanoes.core.util.StringUtils;
-import gov.usgs.volcanoes.core.util.UtilException;
 import gov.usgs.volcanoes.valve3.PlotComponent;
 import gov.usgs.volcanoes.valve3.Plotter;
 import gov.usgs.volcanoes.valve3.Valve3;
@@ -23,6 +22,7 @@ import gov.usgs.volcanoes.vdx.data.Rank;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Generate images for generic data plot to files.
@@ -61,7 +61,7 @@ public class GenericFixedPlotter extends RawDataPlotter {
     accumulateCols = new boolean[columnsCount];
 
     leftLines = 0;
-    axisMap = new LinkedHashMap<Integer, String>();
+    axisMap = new LinkedHashMap<>();
 
     validateDataManipOpts(comp);
 
@@ -117,12 +117,11 @@ public class GenericFixedPlotter extends RawDataPlotter {
     // initialize variables
     boolean exceptionThrown = false;
     String exceptionMsg = "";
-    VDXClient client = null;
-    channelDataMap = new LinkedHashMap<Integer, GenericDataMatrix>();
+    channelDataMap = new LinkedHashMap<>();
     String[] channels = ch.split(",");
 
     // create a map of all the input parameters
-    Map<String, String> params = new LinkedHashMap<String, String>();
+    Map<String, String> params = new LinkedHashMap<>();
     params.put("source", vdxSource);
     params.put("action", "data");
     params.put("st", Double.toString(startTime));
@@ -131,22 +130,16 @@ public class GenericFixedPlotter extends RawDataPlotter {
     addDownsamplingInfo(params);
 
     // checkout a connection to the database
-    Pool<VDXClient> pool = null;
-    pool = Valve3.getInstance().getDataHandler().getVDXClient(vdxClient);
+    Pool<VDXClient> pool = Valve3.getInstance().getDataHandler().getVDXClient(vdxClient);
     if (pool != null) {
-      client = pool.checkout();
+      VDXClient client = pool.checkout();
 
       // iterate through each of the selected channels and place the data in the map
       for (String channel : channels) {
         params.put("ch", channel);
-        GenericDataMatrix data = null;
+        GenericDataMatrix data;
         try {
           data = (GenericDataMatrix) client.getBinaryData(params);
-        } catch (UtilException e) {
-          exceptionThrown = true;
-          exceptionMsg = e.getMessage();
-          logger.debug(exceptionMsg);
-          break;
         } catch (Exception e) {
           exceptionThrown = true;
           exceptionMsg = e.getMessage();
@@ -181,7 +174,7 @@ public class GenericFixedPlotter extends RawDataPlotter {
    * @param v3p Valve3Plot
    * @param comp PlotComponent
    */
-  public void plotData(Valve3Plot v3p, PlotComponent comp, Rank rank) throws Valve3Exception {
+  private void plotData(Valve3Plot v3p, PlotComponent comp, Rank rank) throws Valve3Exception {
 
     // setup the legend for the rank
     String rankLegend = rank.getName();
@@ -205,11 +198,11 @@ public class GenericFixedPlotter extends RawDataPlotter {
     int currentComp = 1;
     int compBoxHeight = comp.getBoxHeight();
 
-    for (int cid : channelDataMap.keySet()) {
+    for (Entry<Integer, GenericDataMatrix> entry : channelDataMap.entrySet()) {
 
       // get the relevant information for this channel
-      Channel channel = channelsMap.get(cid);
-      GenericDataMatrix gdm = channelDataMap.get(cid);
+      Channel channel = channelsMap.get(entry.getKey());
+      GenericDataMatrix gdm = entry.getValue();
 
       // if there is no data for this channel, then resize the plot window
       if (gdm == null || gdm.rows() == 0) {
@@ -313,8 +306,17 @@ public class GenericFixedPlotter extends RawDataPlotter {
       } else {
         // set up the legend
         for (int i = 0; i < legendsCols.length; i++) {
-          channelLegendsCols[i] = String
-              .format("%s %s %s", channel.getCode(), rankLegend, legendsCols[i]);
+          if (useChNames) {
+            channelLegendsCols[i] = String.format("%s %s %s",
+                                                  channel.getName(),
+                                                  rankLegend,
+                                                  legendsCols[i]);
+          } else {
+            channelLegendsCols[i] = String.format("%s %s %s",
+                                                  channel.getCode(),
+                                                  rankLegend,
+                                                  legendsCols[i]);
+          }
         }
 
         // create an individual matrix renderer for each component selected

--- a/Valve3/src/main/java/gov/usgs/volcanoes/valve3/plotter/RawDataPlotter.java
+++ b/Valve3/src/main/java/gov/usgs/volcanoes/valve3/plotter/RawDataPlotter.java
@@ -26,8 +26,10 @@ import gov.usgs.volcanoes.vdx.data.ExportData;
 import gov.usgs.volcanoes.vdx.data.MetaDatum;
 import gov.usgs.volcanoes.vdx.data.Rank;
 import gov.usgs.volcanoes.vdx.data.SuppDatum;
+
 import java.io.IOException;
 import java.io.OutputStream;
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -51,6 +53,7 @@ public abstract class RawDataPlotter extends Plotter {
   protected double endTime;
   protected String ch;
   protected boolean isDrawLegend;
+  protected boolean useChNames;
   protected int rk;
   public boolean ranks = true;
   protected boolean tickMarksX = true;
@@ -84,14 +87,13 @@ public abstract class RawDataPlotter extends Plotter {
   protected Map<Integer, Rank> ranksMap;
 
   protected TreeSet<ExportData> csvData;
-  protected StringBuffer csvText;
+  protected StringBuilder csvText;
   protected Map<String, String> csvCmtBits;
   protected Vector<String[]> csvHdrs;
   protected int csvIndex = 0;
 
   protected boolean[] bypassCols;
   protected boolean[] accumulateCols;
-  protected boolean doAccumulate;
   protected boolean doDespike;
   protected double despikePeriod;
   protected boolean doDetrend;
@@ -108,14 +110,12 @@ public abstract class RawDataPlotter extends Plotter {
 
   protected String outputType;
   protected boolean inclTime;
-  protected SuppDatum[] sdData;
   protected String[] scnl;
   protected double samplingRate = 0.0;
   protected String dataType = null;
 
   protected double timeOffset;
   protected String timeZoneID;
-  protected String dateFormatString;
 
   /**
    * Default constructor.
@@ -123,7 +123,6 @@ public abstract class RawDataPlotter extends Plotter {
   public RawDataPlotter() {
     csvCmtBits = new LinkedHashMap<String, String>();
     csvHdrs = new Vector<String[]>();
-    dateFormatString = "yyyy-MM-dd HH:mm:ss";
   }
 
   /**
@@ -245,6 +244,11 @@ public abstract class RawDataPlotter extends Plotter {
         isDrawLegend = comp.getBoolean("lg");
       } catch (Valve3Exception e) {
         isDrawLegend = true;
+      }
+      try {
+        useChNames = comp.getBoolean("shownames");
+      } catch (Valve3Exception e) {
+        useChNames = true;
       }
       try {
         shape = comp.getString("linetype");
@@ -629,14 +633,15 @@ public abstract class RawDataPlotter extends Plotter {
    * @param nullField what to use for missing fields
    */
   private void addCSVline(Double[][] data, Double time, String decFmt, String nullField) {
-    String line;
+    StringBuilder line;
     String firstDecFmt;
     String nextDecFmt;
     if (inclTime) {
-      line = String.format("%14.3f,", Time.j2kToEw(time)) + J2kSec.toDateString(time);
+      line = new StringBuilder(String.format("%14.3f,",
+                                            Time.j2kToEw(time)) + J2kSec.toDateString(time));
       firstDecFmt = "," + decFmt;
     } else {
-      line = "";
+      line = new StringBuilder("");
       firstDecFmt = decFmt;
     }
     nextDecFmt = "," + decFmt;
@@ -644,15 +649,15 @@ public abstract class RawDataPlotter extends Plotter {
       for (int i = 1; i < group.length; i++) {
         Double v = group[i];
         if (v == null) {
-          line += nullField;
+          line.append(nullField);
         } else if (isCharColumn(i)) {
-          if (v == Double.NaN || v > 255) {
-            line += ", ";
+          if (Double.isNaN(v) || v > 255) {
+            line.append(", ");
           } else {
-            line += "," + new Character((char) (v.intValue()));
+            line.append(",").append(new Character((char) (v.intValue())));
           }
         } else {
-          line += String.format(i == 1 ? firstDecFmt : nextDecFmt, v);
+          line.append(String.format(i == 1 ? firstDecFmt : nextDecFmt, v));
         }
       }
     }
@@ -674,20 +679,20 @@ public abstract class RawDataPlotter extends Plotter {
   private void addXMLline(Double[][] data, Double time, String decFmt, int pos, String timeZone,
       String rank) {
     boolean hasChannels = (csvHdrs.get(1)[2] != null);  // Export has channel information
-    String line;                    // Export line being added
+    StringBuilder line;                    // Export line being added
 
     /* If first line, add header tag */
     if (pos == 1) {
-      line = "\t<DATA>\n";
+      line = new StringBuilder("\t<DATA>\n");
     } else {
-      line = "";
+      line = new StringBuilder("");
     }
     /* Tag for a row of data */
-    line += String.format("\t\t<ROW pos=\"%d\">\n", pos);
+    line.append(String.format("\t\t<ROW pos=\"%d\">%n", pos));
     if (inclTime) {
-      line += String.format("\t\t\t<EPOCH>%1.3f</EPOCH>\n\t\t\t<TIMESTAMP>%s</TIMESTAMP>\n",
-          Time.j2kToEw(time), J2kSec.toDateString(time));
-      line += "\t\t\t<TIMEZONE>" + timeZone + "</TIMEZONE>\n";
+      line.append(String.format("\t\t\t<EPOCH>%1.3f</EPOCH>%n\t\t\t<TIMESTAMP>%s</TIMESTAMP>%n",
+                                Time.j2kToEw(time), J2kSec.toDateString(time)));
+      line.append("\t\t\t<TIMEZONE>").append(timeZone).append("</TIMEZONE>\n");
     }
     String channel = "";    // Channel name
     String tab = "\t\t\t";    // Indent for contents of a row
@@ -703,10 +708,10 @@ public abstract class RawDataPlotter extends Plotter {
         if (hasChannels) {
           if (!channel.equals(hdr[2])) {
             if (i > 1) {
-              line += "\t\t\t</CHANNEL>\n";
+              line.append("\t\t\t</CHANNEL>\n");
             }
             channel = hdr[2];
-            line += "\t\t\t<CHANNEL>\n\t\t\t\t<code>" + channel + "</code>\n";
+            line.append("\t\t\t<CHANNEL>\n\t\t\t\t<code>").append(channel).append("</code>\n");
             tab = "\t\t\t\t";
             showRank = true;
           }
@@ -715,30 +720,30 @@ public abstract class RawDataPlotter extends Plotter {
         }
         if (showRank) {
           if (hdr[1] != null) {
-            line += tab + "<rank>" + hdr[1] + "</rank>\n";
+            line.append(tab).append("<rank>").append(hdr[1]).append("</rank>\n");
           } else if (hasRank) {
-            line += tab + "<rank>" + rank + "</rank>\n";
+            line.append(tab).append("<rank>").append(rank).append("</rank>\n");
           }
         }
 
         Double v = group[i];    // Actual exported data value
         if (v != null) {
-          line += tab + "<" + tag + ">";
+          line.append(tab).append("<").append(tag).append(">");
           if (isCharColumn(i)) {
-            if (v == Double.NaN || v > 255) {
+            if (Double.isNaN(v) || v > 255) {
               ;
             } else {
-              line += new Character((char) (v.intValue()));
+              line.append(new Character((char) (v.intValue())));
             }
           } else {
-            line += String.format(decFmt, v);
+            line.append(String.format(decFmt, v));
           }
-          line += "</" + tag + ">\n";
+          line.append("</").append(tag).append(">\n");
         }
       }
     }
     if (hasChannels) {
-      line += "\t\t\t</CHANNEL>\n";
+      line.append("\t\t\t</CHANNEL>\n");
     }
     csvText.append(line);
     csvText.append("\t\t</ROW>\n");
@@ -758,30 +763,31 @@ public abstract class RawDataPlotter extends Plotter {
   private void addJsonLine(Double[][] data, Double time, String decFmt, int pos, String timeZone,
       String rank) {
     boolean hasChannels = (csvHdrs.get(1)[2] != null);  // Export has channel information
-    String line;                    // Export line being added
+    StringBuilder line;                    // Export line being added
 
     /* If first line, add header tag */
     if (pos == 1) {
-      line = "\t\"data\":[\n";
+      line = new StringBuilder("\t\"data\":[\n");
     } else {
-      line = ",\n";
+      line = new StringBuilder(",\n");
     }
-    line += "\t\t{";
+    line.append("\t\t{");
     if (inclTime) {
-      line += String.format("\"EPOCH\":%1.3f,\"TIMESTAMP\":\"%s\",", Time.j2kToEw(time),
-          J2kSec.toDateString(time));
-      line += "\"TIMEZONE\":\"" + timeZone + "\"" + (hasChannels ? ",\n" : "");
+      line.append(String.format("\"EPOCH\":%1.3f,\"TIMESTAMP\":\"%s\",", Time.j2kToEw(time),
+                                J2kSec.toDateString(time)));
+      line.append("\"TIMEZONE\":\"").append(timeZone).append("\"")
+                                                     .append((hasChannels ? ",\n" : ""));
     }
 
     if (hasChannels) {
-      line += "\t\t\"CHANNELS\":[\n";
+      line.append("\t\t\"CHANNELS\":[\n");
     }
     String channel = "";
     int hdrIdx = 1;      // Current column of export
     boolean hasRank = (!rank.equals(""));    // Export has rank information
     for (Double[] group : data) {
       if (hdrIdx != 1 && hasChannels) {
-        line += ",\n";
+        line.append(",\n");
       }
       for (int i = 1; i < group.length; i++) {
         hdrIdx++;
@@ -791,7 +797,7 @@ public abstract class RawDataPlotter extends Plotter {
         if (hasChannels) {
           if (!channel.equals(hdr[2])) {
             channel = hdr[2];
-            line += "\t\t\t{\"code\":\"" + channel + "\"";
+            line.append("\t\t\t{\"code\":\"").append(channel).append("\"");
             showRank = true;
           }
         } else {
@@ -799,27 +805,27 @@ public abstract class RawDataPlotter extends Plotter {
         }
         if (showRank) {
           if (hdr[1] != null) {
-            line += ",\n\t\t\t\"rank\":\"" + hdr[1] + "\"";
+            line.append(",\n\t\t\t\"rank\":\"").append(hdr[1]).append("\"");
           } else if (hasRank) {
-            line += ",\n\t\t\t\"rank\":\"" + rank + "\"";
+            line.append(",\n\t\t\t\"rank\":\"").append(rank).append("\"");
           }
         }
 
         Double v = group[i];
         if (v != null) {
-          line += String.format(",\n\t\t\t\"%s\":", tag);
+          line.append(String.format(",%n\t\t\t\"%s\":", tag));
           if (isCharColumn(i)) {
-            if (v == Double.NaN || v > 255) {
-              line += "\"\"";
+            if (Double.isNaN(v) || v > 255) {
+              line.append("\"\"");
             } else {
-              line += "\"" + new Character((char) (v.intValue())) + "\"";
+              line.append("\"").append(new Character((char) (v.intValue()))).append("\"");
             }
           } else {
-            line += String.format(decFmt, v);
+            line.append(String.format(decFmt, v));
           }
         }
       }
-      line += "}";
+      line.append("}");
     }
     csvText.append(line);
     if (hasChannels) {
@@ -932,17 +938,16 @@ public abstract class RawDataPlotter extends Plotter {
     if (csvCmtBits.containsKey("datatype")) {
       cmtLines.add("datatype=" + csvCmtBits.get("datatype"));
     }
-    csvText = new StringBuffer();
-    Vector<String> myCmtLines = cmtLines;
+    csvText = new StringBuilder();
 
     if (outToCsv) {
       for (String comment : comments) {
-        csvText.append("#" + comment + "\n");
+        csvText.append("#").append(comment).append("\n");
       }
-      for (String comment : myCmtLines) {
-        csvText.append("#" + comment + "\n");
+      for (String comment : cmtLines) {
+        csvText.append("#").append(comment).append("\n");
       }
-      StringBuffer hdrLine = new StringBuffer();
+      StringBuilder hdrLine = new StringBuilder();
       boolean first = true;
       for (String[] s : csvHdrs) {
         String hdr;
@@ -970,7 +975,7 @@ public abstract class RawDataPlotter extends Plotter {
             + "</COMMENTLINE>\n");
         i++;
       }
-      for (String comment : myCmtLines) {
+      for (String comment : cmtLines) {
         csvText.append("\t\t<COMMENTLINE pos=\"" + i + "\">" + comment.replaceAll("&", "&amp;")
             + "</COMMENTLINE>\n");
         i++;
@@ -984,7 +989,7 @@ public abstract class RawDataPlotter extends Plotter {
         csvText.append(sep + comment);
         sep = "\",\n\t\t\"";
       }
-      for (String comment : myCmtLines) {
+      for (String comment : cmtLines) {
         csvText.append(sep + comment);
         sep = "\",\n\t\t\"";
       }

--- a/Valve3Web/pom.xml
+++ b/Valve3Web/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>gov.usgs.volcanoes</groupId>
     <artifactId>valve</artifactId>
-    <version>3.6.3</version>
+    <version>3.7.0</version>
   </parent>
   <artifactId>valve3web</artifactId>
   <packaging>war</packaging>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>gov.usgs.volcanoes</groupId>
       <artifactId>valve3</artifactId>
-      <version>3.6.3</version>
+      <version>3.7.0</version>
       <exclusions>
         <exclusion>
           <groupId>colt</groupId>

--- a/Valve3Web/resources/js/menu.js
+++ b/Valve3Web/resources/js/menu.js
@@ -971,6 +971,18 @@ function toggleTimeShortcutPanel(event)
 }
 
 /**
+ *  Looks at current value of the Show Names checkbox
+ */
+function getShowNamesChkbox(form) {
+  var showNames = false;
+  var chk = form.elements[this.currentMenu.id + '_shownames'];
+  if (chk) {
+    showNames = chk.checked;
+  }
+  return showNames;
+}
+
+/**
  *  Check the current geographic filter interface element to find out the active geo filter.
  *  For example "Alaska": return appropriate latitude and longitude to define the area. This
  *  is parsed out of the text array 'value' stored in the popup menu,
@@ -1242,6 +1254,22 @@ Menu.prototype.submit = function() {
   // run the presubmit, and if it passes, submit the request
   if (this.presubmit(pr, pc)) {
     loadXML(this.id + " plot", pr.getURL());
+  }
+}
+
+/**
+ *  Swap between channel code and channel name display
+ */
+Menu.prototype.showNames = function() {
+  var form = this.getForm();
+  var select = form.elements["selector:ch"];
+  shownames = getShowNamesChkbox(form);
+  for (var i = 0; i < this.allChannels.length; i++) {
+    if (shownames) {
+      this.allChannels[i].text = this.allChannels[i].value.split(":")[2].replace(/\$/g,' ');
+    } else {
+      this.allChannels[i].text = this.allChannels[i].value.split(":")[1].replace(/\$/g,' ');
+    }
   }
 }
 

--- a/Valve3Web/src/main/webapp/menu/genericfixedmenu.html
+++ b/Valve3Web/src/main/webapp/menu/genericfixedmenu.html
@@ -6,6 +6,7 @@
         <div class="box">
     <h1>Channels</h1>
     <h1><label for="showall">Show All</label> <input type="checkbox" id="showall" name="skip:showall"></h1>
+    <h1><label for="shownames">Names</label> <input type="checkbox" id="shownames" name="shownames"</h1>
     <p><select class="w100p" multiple="multiple" size="15" name="selector:ch">
     </select></p>
     </div>

--- a/Valve3Web/src/main/webapp/menu/genericfixedmenu.js
+++ b/Valve3Web/src/main/webapp/menu/genericfixedmenu.js
@@ -58,6 +58,12 @@ create_genericfixedmenu = function(menu) {
       if (currentMenu)
         currentMenu.filterChanged();
     }, false);
+
+    sel = document.getElementById(this.id + '_shownames');
+    addListener(sel, 'change', function() {
+      if (currentMenu)
+        currentMenu.showNames();
+    }, false);
   }
 
   // override the default presubmit function

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>gov.usgs.volcanoes</groupId>
   <artifactId>valve</artifactId>
-  <version>3.6.3</version>
+  <version>3.7.0</version>
   <packaging>pom</packaging>
 
   <name>valve</name>


### PR DESCRIPTION
Users plotting genericfixed datasets can now choose to display station
names instead of codes in both the station selection box as well as on
the generated chart.

Also cleaned up some FindBugs issues in the files already being edited.

Fixes issue #17 